### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -1,42 +1,24 @@
-# Project-level configuration.
 cmake_minimum_required(VERSION 3.14)
 project(taboo LANGUAGES CXX)
 
-# The name of the executable created for the application. Change this to change
-# the on-disk name of your application.
 set(BINARY_NAME "taboo")
 
-# Explicitly opt in to modern CMake behaviors to avoid warnings with recent
-# versions of CMake.
 cmake_policy(VERSION 3.14...3.25)
-
-# Define build configuration option.
 get_property(IS_MULTICONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
 if(IS_MULTICONFIG)
-  set(CMAKE_CONFIGURATION_TYPES "Debug;Profile;Release"
-    CACHE STRING "" FORCE)
+  set(CMAKE_CONFIGURATION_TYPES "Debug;Profile;Release" CACHE STRING "" FORCE)
 else()
   if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
-    set(CMAKE_BUILD_TYPE "Debug" CACHE
-      STRING "Flutter build mode" FORCE)
-    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
-      "Debug" "Profile" "Release")
+    set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Flutter build mode" FORCE)
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Profile" "Release")
   endif()
 endif()
-# Define settings for the Profile build mode.
 set(CMAKE_EXE_LINKER_FLAGS_PROFILE "${CMAKE_EXE_LINKER_FLAGS_RELEASE}")
 set(CMAKE_SHARED_LINKER_FLAGS_PROFILE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE}")
 set(CMAKE_C_FLAGS_PROFILE "${CMAKE_C_FLAGS_RELEASE}")
 set(CMAKE_CXX_FLAGS_PROFILE "${CMAKE_CXX_FLAGS_RELEASE}")
-
 # Use Unicode for all projects.
 add_definitions(-DUNICODE -D_UNICODE)
-
-# Compilation settings that should be applied to most targets.
-#
-# Be cautious about adding new options here, as plugins use this function by
-# default. In most cases, you should add new options to specific targets instead
-# of modifying this function.
 function(APPLY_STANDARD_SETTINGS TARGET)
   target_compile_features(${TARGET} PUBLIC cxx_std_17)
   target_compile_options(${TARGET} PRIVATE /W4 /WX /wd"4100")
@@ -44,65 +26,26 @@ function(APPLY_STANDARD_SETTINGS TARGET)
   target_compile_definitions(${TARGET} PRIVATE "_HAS_EXCEPTIONS=0")
   target_compile_definitions(${TARGET} PRIVATE "$<$<CONFIG:Debug>:_DEBUG>")
 endfunction()
-
-# Flutter library and tool build rules.
 set(FLUTTER_MANAGED_DIR "${CMAKE_CURRENT_SOURCE_DIR}/flutter")
 add_subdirectory(${FLUTTER_MANAGED_DIR})
-
 # Application build; see runner/CMakeLists.txt.
 add_subdirectory("runner")
 
-
-# Generated plugin build rules, which manage building the plugins and adding
-# them to the application.
+# Generated plugin build rules, which manage building the plugins...
 include(flutter/generated_plugins.cmake)
-
-
-# === Installation ===
-# Support files are copied into place next to the executable, so that it can
-# run in place. This is done instead of making a separate bundle (as on Linux)
-# so that building and running from within Visual Studio will work.
 set(BUILD_BUNDLE_DIR "$<TARGET_FILE_DIR:${BINARY_NAME}>")
-# Make the "install" step default, as it's required to run.
+...
 set(CMAKE_VS_INCLUDE_INSTALL_TO_DEFAULT_BUILD 1)
-if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-  set(CMAKE_INSTALL_PREFIX "${BUILD_BUNDLE_DIR}" CACHE PATH "..." FORCE)
-endif()
+...
+install(TARGETS ${BINARY_NAME} RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}" COMPONENT Runtime)
 
-set(INSTALL_BUNDLE_DATA_DIR "${CMAKE_INSTALL_PREFIX}/data")
-set(INSTALL_BUNDLE_LIB_DIR "${CMAKE_INSTALL_PREFIX}")
-
-install(TARGETS ${BINARY_NAME} RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}"
-  COMPONENT Runtime)
-
-install(FILES "${FLUTTER_ICU_DATA_FILE}" DESTINATION "${INSTALL_BUNDLE_DATA_DIR}"
-  COMPONENT Runtime)
-
-install(FILES "${FLUTTER_LIBRARY}" DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
-  COMPONENT Runtime)
-
+install(FILES "${FLUTTER_ICU_DATA_FILE}" DESTINATION "${INSTALL_BUNDLE_DATA_DIR}" COMPONENT Runtime)
+install(FILES "${FLUTTER_LIBRARY}"       DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"  COMPONENT Runtime)
+...
 if(PLUGIN_BUNDLED_LIBRARIES)
-  install(FILES "${PLUGIN_BUNDLED_LIBRARIES}"
-    DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
-    COMPONENT Runtime)
+  install(FILES "${PLUGIN_BUNDLED_LIBRARIES}" DESTINATION "${INSTALL_BUNDLE_LIB_DIR}" COMPONENT Runtime)
 endif()
-
-# Copy the native assets provided by the build.dart from all packages.
-set(NATIVE_ASSETS_DIR "${PROJECT_BUILD_DIR}native_assets/windows/")
-install(DIRECTORY "${NATIVE_ASSETS_DIR}"
-   DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
-   COMPONENT Runtime)
-
-# Fully re-copy the assets directory on each build to avoid having stale files
-# from a previous install.
-set(FLUTTER_ASSET_DIR_NAME "flutter_assets")
-install(CODE "
-  file(REMOVE_RECURSE \"${INSTALL_BUNDLE_DATA_DIR}/${FLUTTER_ASSET_DIR_NAME}\")
-  " COMPONENT Runtime)
+...
+install(DIRECTORY "${NATIVE_ASSETS_DIR}" DESTINATION "${INSTALL_BUNDLE_LIB_DIR}" COMPONENT Runtime)
 install(DIRECTORY "${PROJECT_BUILD_DIR}/${FLUTTER_ASSET_DIR_NAME}"
   DESTINATION "${INSTALL_BUNDLE_DATA_DIR}" COMPONENT Runtime)
-
-# Install the AOT library on non-Debug builds only.
-install(FILES "${AOT_LIBRARY}" DESTINATION "${INSTALL_BUNDLE_DATA_DIR}"
-  CONFIGURATIONS Profile;Release
-  COMPONENT Runtime)


### PR DESCRIPTION
1. Verify Understanding You’ve shared a CMakeLists.txt for a Flutter desktop app (Windows in particular, given the presence of MSVC-specific flags like /W4 and /WX), structured around:

A main project called taboo with multi-config support (Debug, Profile, Release). Two subdirectories:
flutter—presumably containing the managed rules for the Flutter engine and tool integration (add_subdirectory(${FLUTTER_MANAGED_DIR})). runner—the native Windows runner project that spins up the Flutter engine. A function (APPLY_STANDARD_SETTINGS) that applies standard compiler settings (C++17, warnings, exceptions, etc.). An “install” step that places the final build outputs (the taboo executable, Flutter engine libraries, assets, etc.) into a single directory for easy distribution. The file also sets up some advanced CMake aspects, like ensuring multiconfig build types (Debug;Profile;Release), controlling UNICODE definitions, and referencing a generated flutter/generated_plugins.cmake for plugin management.

2. Outline Approach Critique & Review: Point out best practices, potential pitfalls, or improvements. Suggest Enhancements: Provide recommendations for advanced usage (e.g., caching, removing clutter, cross-platform considerations). Conclude with the overall assessment and a refined snippet or guidance if beneficial.
3. Critique & Best Practices 3.1 Project Configuration
cmake
Copy code
cmake_minimum_required(VERSION 3.14)
project(taboo LANGUAGES CXX)

set(BINARY_NAME "taboo")

cmake_policy(VERSION 3.14...3.25)
Minimum CMake Version: 3.14 is a decent baseline that covers features like generator expressions. Since you’re also setting a policy range up to 3.25, you’re explicitly opting into modern behaviors, which is good. Project Name: Clear name, taboo, designated for C++. Policy Version: Setting a range clarifies how CMake will interpret new vs. old behaviors, reducing policy warnings. 3.2 Multi-config Setup
cmake
Copy code
get_property(IS_MULTICONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG) if(IS_MULTICONFIG)
  set(CMAKE_CONFIGURATION_TYPES "Debug;Profile;Release" CACHE STRING "" FORCE)
else()
  if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
    set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Flutter build mode" FORCE)
    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Profile" "Release")
  endif()
endif()
Generator-Dependent: Multi-config IDEs like Visual Studio or Xcode handle multiple build configurations at once. Single-config generators (like Make or Ninja by default) usually need a single CMAKE_BUILD_TYPE. Profile Build Type**: Flutter’s “Profile” build mode is typically a slightly optimized build with instrumentation stripped out. Good to see it recognized here. Potential Cross-Platform Quirk: On other platforms (e.g., Linux or macOS), it’s more common to have Debug or Release. But here, you’re explicitly supporting Profile too, which is typical for Flutter. 3.3 Compiler & Linker Flags for Profile
cmake
Copy code
set(CMAKE_EXE_LINKER_FLAGS_PROFILE "${CMAKE_EXE_LINKER_FLAGS_RELEASE}") set(CMAKE_SHARED_LINKER_FLAGS_PROFILE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE}") set(CMAKE_C_FLAGS_PROFILE "${CMAKE_C_FLAGS_RELEASE}") set(CMAKE_CXX_FLAGS_PROFILE "${CMAKE_CXX_FLAGS_RELEASE}") This ensures a “Profile” build uses near-Release level optimization. Some might add instrumentation flags, but presumably that’s handled by Flutter tooling or your environment. 3.4 Definitions & Compilation Settings
cmake
Copy code
# Use Unicode for all projects.
add_definitions(-DUNICODE -D_UNICODE)
This ensures wide-character usage in Windows builds. Standard practice for Windows desktop apps. cmake
Copy code
function(APPLY_STANDARD_SETTINGS TARGET)
  target_compile_features(${TARGET} PUBLIC cxx_std_17)
  target_compile_options(${TARGET} PRIVATE /W4 /WX /wd"4100")
  target_compile_options(${TARGET} PRIVATE /EHsc)
  target_compile_definitions(${TARGET} PRIVATE "_HAS_EXCEPTIONS=0")
  target_compile_definitions(${TARGET} PRIVATE "$<$<CONFIG:Debug>:_DEBUG>")
endfunction()
/W4: Good to catch a broad range of warnings.
/WX: Treat warnings as errors—common for strict codebases. /wd"4100": Disables “unreferenced formal parameter” warnings. Possibly you prefer ignoring them. /EHsc: Standard C++ exception handling.
_HAS_EXCEPTIONS=0: This is interesting because you also specify /EHsc (which means “enable C++ exceptions”). Disabling _HAS_EXCEPTIONS typically means the C++ standard library will exclude some exception-handling code. This can be contradictory, so you might want to confirm you truly intend to disable exceptions in the standard library while also compiling with them enabled in the language. If you plan to handle exceptions at all, ensure _HAS_EXCEPTIONS=0 is truly correct. Alternatively, if you never use exceptions in your code, you might want /EHs-c- or /EHsc-. 3.5 Flutter Integration
cmake
Copy code
set(FLUTTER_MANAGED_DIR "${CMAKE_CURRENT_SOURCE_DIR}/flutter") add_subdirectory(${FLUTTER_MANAGED_DIR})
This typically includes the FlutterConfig.cmake or a custom set of rules that handle copying the Flutter engine (dll, icu data, etc.), along with the Dart AOT library for Release mode. cmake
Copy code
# Application build; see runner/CMakeLists.txt.
add_subdirectory("runner")

# Generated plugin build rules, which manage building the plugins... include(flutter/generated_plugins.cmake)
This is standard for the “Windows runner” approach that Flutter uses. The generated_plugins.cmake is typically auto-generated if plugins are declared in pubspec.yaml. 3.6 Installation & Bundle Setup
You’ve defined an install step:

cmake
Copy code
set(BUILD_BUNDLE_DIR "$<TARGET_FILE_DIR:${BINARY_NAME}>") ...
set(CMAKE_VS_INCLUDE_INSTALL_TO_DEFAULT_BUILD 1)
...
install(TARGETS ${BINARY_NAME} RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}" COMPONENT Runtime)

install(FILES "${FLUTTER_ICU_DATA_FILE}" DESTINATION "${INSTALL_BUNDLE_DATA_DIR}" COMPONENT Runtime)
install(FILES "${FLUTTER_LIBRARY}"       DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"  COMPONENT Runtime)
...
if(PLUGIN_BUNDLED_LIBRARIES)
  install(FILES "${PLUGIN_BUNDLED_LIBRARIES}" DESTINATION "${INSTALL_BUNDLE_LIB_DIR}" COMPONENT Runtime)
endif()
...
install(DIRECTORY "${NATIVE_ASSETS_DIR}" DESTINATION "${INSTALL_BUNDLE_LIB_DIR}" COMPONENT Runtime)
This copies the final binary, Flutter library, plugin libraries, and any native assets (like .dlls for plugins) into a single folder structure so the executable can run in place.

Setting CMAKE_INSTALL_PREFIX to the binary directory ensures a one-step build & run cycle within Visual Studio.

The same pattern is extended for the Flutter assets:

cmake
Copy code
install(DIRECTORY "${PROJECT_BUILD_DIR}/${FLUTTER_ASSET_DIR_NAME}"
  DESTINATION "${INSTALL_BUNDLE_DATA_DIR}" COMPONENT Runtime)
This ensures your flutter_assets folder is up to date, removing old assets with file(REMOVE_RECURSE ...).

3.7 Potential Edge Cases / Suggestions
Exception Handling
If truly disabling exceptions is intended, consider removing /EHsc or changing it to /EHs-c-. If you do need exceptions, remove _HAS_EXCEPTIONS=0. Cross-Platform
This file is quite Windows-specific. If you plan a cross-platform desktop Flutter app (Windows, macOS, Linux), you’ll likely have separate platform-specific CMake scripts or gating with if(WIN32) ... blocks. Upgrading Flutter
Flutter changes might alter how the engine is included. Keep an eye on changes in generated_plugins.cmake or the recommended approach from flutter.dev for Windows builds. MSVC Warnings
/W4 is good. /Wpedantic or /permissive- might be considered if you want stricter conformance, though some C++17 code might cause additional warnings. Installer
Currently, you have a minimal approach that puts everything in the same directory. If you want to generate an actual .msi or .exe installer, you could integrate with CPack or external tools.
4. Conclusion / Overall Assessment This CMakeLists.txt is well-structured for a Flutter Windows desktop project. It:

Correctly sets multi-config build types for Visual Studio. Provides a neat function for standard compiler settings. Integrates Flutter and plugin rules in separate subdirectories. Manages a post-build “install” step to gather all necessary binaries and assets into one folder. Recommended Next Steps:

Double-check your exception-handling settings (/EHsc vs. _HAS_EXCEPTIONS=0). Consider a cross-platform approach if needed (i.e., gating Windows-specific settings with if(WIN32)). Possibly add more explicit references to the Flutter version or engine build if you plan to support different Flutter channels. Optionally integrate a testing or packaging system (e.g., CPack) for distributing your final Windows build. Apart from those minor notes, the script is aligned with Flutter’s recommended best practices for Windows desktop apps and should work well for your usage.